### PR TITLE
Update addon-developer-support and use Services global variable if possible

### DIFF
--- a/content/ToneQuillaPlay.jsm
+++ b/content/ToneQuillaPlay.jsm
@@ -136,7 +136,9 @@ var ToneQuillaPlay = {
 
     const { NetUtil }  = Cu.import("resource://gre/modules/NetUtil.jsm"),
           { FileUtils } = Cu.import("resource://gre/modules/FileUtils.jsm"),
-          { Services } = Cu.import('resource://gre/modules/Services.jsm');
+          Services = globalThis.Services || Cu.import(
+            'resource://gre/modules/Services.jsm'
+          ).Services;
   
     try {
       that._playTimer = Cc["@mozilla.org/timer;1"].createInstance(Ci.nsITimer);

--- a/content/api/DomContentScript/implementation.js
+++ b/content/api/DomContentScript/implementation.js
@@ -5,7 +5,9 @@ var { ExtensionCommon } = ChromeUtils.import(
 var { ExtensionUtils } = ChromeUtils.import(
   "resource://gre/modules/ExtensionUtils.jsm"
 );
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 var { ExtensionError } = ExtensionUtils;
 

--- a/content/api/NotifyTools/README.md
+++ b/content/api/NotifyTools/README.md
@@ -10,6 +10,10 @@ and back in when the task has been finished.
 
 More details can be found in [this update tutorial](https://github.com/thundernest/addon-developer-support/wiki/Tutorial:-Convert-add-on-parts-individually-by-using-a-messaging-system).
 
+# Example
+
+This repository includes the [NotifyToolsExample Add-On](https://github.com/thundernest/addon-developer-support/raw/master/auxiliary-apis/NotifyTools/notifyToolsExample.zip), showcasing how the NotifyTools can be used.
+
 # Usage
 
 Add the [NotifyTools API](https://github.com/thundernest/addon-developer-support/tree/master/auxiliary-apis/NotifyTools) to your add-on. Your `manifest.json` needs an entry like this:
@@ -56,7 +60,7 @@ notifyTools.notifyBackground({command: "doSomething"}).then((data) => {
 });
 ```
 
-Include the [notifyTools.js](https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools) script in your Experiment script to be able to use `notifyTools.notifyBackground()`.
+Include the [notifyTools.js](https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools) script in your Experiment script to be able to use `notifyTools.notifyBackground()`. If you are injecting the script into a global Thunderbird window object, make sure to wrap it in your custom namespace, to prevent clashes with other add-ons.
 
 **Note**: If multiple `onNotifyBackground` listeners are registered in the WebExtension's background page and more than one is returning data, the value
 from the first one is returned to the Experiment. This may lead to inconsistent behavior, so make sure that for each
@@ -75,9 +79,9 @@ messenger.NotifyTools.notifyExperiment({command: "doSomething"}).then((data) => 
 
 The receiving Experiment script needs to include the [notifyTools.js](https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools) script  and must setup a listener using the following methods:
 
-### registerListener(callback);
+### addListener(callback);
 
-Registers a callback function, which is called when a notification from the WebExtension's background page has been received. The `registerListener()` function returns an `id` which can be used to remove the listener again.
+Adds a callback function, which is called when a notification from the WebExtension's background page has been received. The `addListener()` function returns an `id` which can be used to remove the listener again.
 
 Example:
 
@@ -86,8 +90,47 @@ function doSomething(data) {
   console.log(data);
   return true;
 }
-let id = notifyTools.registerListener(doSomething);
+let id = notifyTools.addListener(doSomething);
 ```
+
+**Note**: NotifyTools currently is not 100% compatible with the behavior of
+runtime.sendMessage. While runtime messaging is ignoring non-Promise return
+values, NotifyTools only ignores `null`.
+
+Why does this matter? Consider the following three listeners:
+ 
+```
+async function dominant_listener(data) {
+ if (data.type == "A") {
+   return { msg: "I should answer only type A" };
+ }
+}
+ 
+function silent_listener(data) {
+ if (data.type == "B") {
+   return { msg: "I should answer only type B" };
+ }
+}
+
+function selective_listener(data) {
+ if (data.type == "C") {
+   return Promise.resolve({ msg: "I should answer only type C" });
+ }
+}
+```
+ 
+When all 3 listeners are registered for the runtime.onMessage event,
+the dominant listener will always respond, even for `data.type != "A"` requests,
+because it is always returning a Promise (it is an async function). The return
+value of the silent listener is ignored, and the selective listener returns a
+value just for `data.type == "C"`. But since the dominant listener also returns
+`null` for these requests, the actual return value depends on which listener is faster
+and/or was registered first.
+ 
+All notifyTools listener however ignore only `null` return values (so `null` can
+actually never be returned). The above dominant listener will only respond to 
+`type == "A"` requests, the silent listener will only respond to `type == "B"` 
+requests and the selective listener will respond only to `type == "C"` requests.
 
 ### removeListener(id)
 
@@ -99,10 +142,10 @@ Example:
 notifyTools.removeListener(id);
 ```
 
-### enable()
+### removeAllListeners()
 
-The [notifyTools.js](https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools) script attaches its `enable()` method to the `load` event of the current window. If the script is loaded into a window-less environment, `enable()` needs to be called manually.
+You must remove all added listeners when your add-on is disabled/reloaded. Instead of calling `removeListener()` for each added listener, you may call `removeAllListeners()`.
 
-### disable()
+### setAddOnId(add-on-id)
 
-The [notifyTools.js](https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools) script attaches its `disable()` method to the `unload` event of the current window. If the script is loaded into a window-less environment, `disable()` needs to be called manually.
+The `notifyTools.js` script needs to know the ID of your add-on to be able to listen for messages. You may either define the ID directly in the first line of the script, or set it using `setAddOnId()`.

--- a/content/api/NotifyTools/schema.json
+++ b/content/api/NotifyTools/schema.json
@@ -1,6 +1,6 @@
 [
   {
-    "namespace": "NotifyTools",    
+    "namespace": "NotifyTools",
     "events": [
       {
         "name": "onNotifyBackground",

--- a/content/filtaquilla-util.js
+++ b/content/filtaquilla-util.js
@@ -139,7 +139,9 @@ FiltaQuilla.Util = {
 	} ,
 
 	findMailTab: function findMailTab(tabmail, URL) {
-    var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+    var Services = globalThis.Services || ChromeUtils.import(
+      "resource://gre/modules/Services.jsm"
+    ).Services;
 		// mail: tabmail.tabInfo[n].browser
 		let baseURL = FiltaQuilla.Util.getBaseURI(URL),
 				numTabs = FiltaQuilla.Util.getTabInfoLength(tabmail);
@@ -433,7 +435,9 @@ FiltaQuilla.Util = {
 	} ,
   
   localize: function(window, buttons = null) {
-    var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+    var Services = globalThis.Services || ChromeUtils.import(
+      "resource://gre/modules/Services.jsm"
+    ).Services;
     var { ExtensionParent } = ChromeUtils.import("resource://gre/modules/ExtensionParent.jsm");
     let extension = ExtensionParent.GlobalManager.getExtension("filtaquilla@mesquilla.com");
     Services.scriptloader.loadSubScript(
@@ -743,7 +747,9 @@ FiltaQuilla.Util = {
 
 // the following adds the notifyTools API as a util method to communicate with the background page
 // this mechanism will be used to replace legacy code with API calls.
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 var { ExtensionParent } = ChromeUtils.import("resource://gre/modules/ExtensionParent.jsm");
 FiltaQuilla.Util.extension = ExtensionParent.GlobalManager.getExtension("filtaquilla@mesquilla.com");
 Services.scriptloader.loadSubScript(

--- a/content/filtaquilla.js
+++ b/content/filtaquilla.js
@@ -34,7 +34,9 @@
 {
  
   Components.utils.import("resource://filtaquilla/inheritedPropertiesGrid.jsm");
-  var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+  var Services = globalThis.Services || ChromeUtils.import(
+    "resource://gre/modules/Services.jsm"
+  ).Services;
   var { MimeParser } = ChromeUtils.import("resource:///modules/mimeParser.jsm");
   var { MailUtils } = ChromeUtils.import("resource:///modules/MailUtils.jsm");
   

--- a/content/fq_FilterEditor.js
+++ b/content/fq_FilterEditor.js
@@ -20,7 +20,9 @@
  */
 
 {
-  var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+  var Services = globalThis.Services || ChromeUtils.import(
+    "resource://gre/modules/Services.jsm"
+  ).Services;
   Services.scriptloader.loadSubScript("chrome://filtaquilla/content/filtaquilla-util.js") // FiltaQuilla object
 
   const util = FiltaQuilla.Util,

--- a/content/options.js
+++ b/content/options.js
@@ -27,7 +27,9 @@
  * ***** END LICENSE BLOCK *****
  */
  
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 Services.scriptloader.loadSubScript("chrome://filtaquilla/content/filtaquilla-util.js") // FiltaQuilla object
 // const util = FiltaQuilla.Util;
 

--- a/content/scripts/filtaquilla-messenger.js
+++ b/content/scripts/filtaquilla-messenger.js
@@ -1,4 +1,6 @@
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 Services.scriptloader.loadSubScript("chrome://filtaquilla/content/filtaquilla-util.js", window, "UTF-8");
 Services.scriptloader.loadSubScript("chrome://filtaquilla/content/filtaquilla.js", window, "UTF-8");

--- a/content/scripts/notifyTools.js
+++ b/content/scripts/notifyTools.js
@@ -1,4 +1,4 @@
-// Set this to the ID of your add-on.
+// Set this to the ID of your add-on, or call notifyTools.setAddonID().
 var ADDON_ID = "filtaquilla@mesquilla.com";
 
 /*
@@ -8,7 +8,17 @@ var ADDON_ID = "filtaquilla@mesquilla.com";
  * For usage descriptions, please check:
  * https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools
  *
- * Version: 1.3
+ * Version 1.6
+ * - adjusted to Thunderbird Supernova (Services is now in globalThis)
+ *
+ * Version 1.5
+ * - deprecate enable(), disable() and registerListener()
+ * - add setAddOnId()
+ *
+ * Version 1.4
+ * - auto enable/disable
+ *
+ * Version 1.3
  * - registered listeners for notifyExperiment can return a value
  * - remove WindowListener from name of observer
  *
@@ -19,21 +29,30 @@ var ADDON_ID = "filtaquilla@mesquilla.com";
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || 
+  ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 
 var notifyTools = {
   registeredCallbacks: {},
   registeredCallbacksNextId: 1,
+  addOnId: ADDON_ID,
+
+  setAddOnId: function (addOnId) {
+    this.addOnId = addOnId;
+  },
 
   onNotifyExperimentObserver: {
     observe: async function (aSubject, aTopic, aData) {
-      if (ADDON_ID == "") {
+      if (notifyTools.addOnId == "") {
         throw new Error("notifyTools: ADDON_ID is empty!");
       }
-      if (aData != ADDON_ID) {
+      if (aData != notifyTools.addOnId) {
         return;
       }
       let payload = aSubject.wrappedJSObject;
+
+      // Make sure payload has a resolve function, which we use to resolve the
+      // observer notification.
       if (payload.resolve) {
         let observerTrackerPromises = [];
         // Push listener into promise array, so they can run in parallel
@@ -61,17 +80,26 @@ var notifyTools = {
           payload.resolve(results[0]);
         }
       } else {
-        // Just call the listener.
+        // Older version of NotifyTools, which is not sending a resolve function, deprecated.
+        console.log("Please update the notifyTools API to at least v1.5");
         for (let registeredCallback of Object.values(
           notifyTools.registeredCallbacks
         )) {
           registeredCallback(payload.data);
         }
-      }    
+      }
     },
   },
 
-  registerListener: function (listener) {
+  addListener: function (listener) {
+    if (Object.values(this.registeredCallbacks).length == 0) {
+      Services.obs.addObserver(
+        this.onNotifyExperimentObserver,
+        "NotifyExperimentObserver",
+        false
+      );
+    }
+
     let id = this.registeredCallbacksNextId++;
     this.registeredCallbacks[id] = listener;
     return id;
@@ -79,50 +107,61 @@ var notifyTools = {
 
   removeListener: function (id) {
     delete this.registeredCallbacks[id];
+    if (Object.values(this.registeredCallbacks).length == 0) {
+      Services.obs.removeObserver(
+        this.onNotifyExperimentObserver,
+        "NotifyExperimentObserver"
+      );
+    }
+  },
+
+  removeAllListeners: function () {
+    if (Object.values(this.registeredCallbacks).length != 0) {
+      Services.obs.removeObserver(
+        this.onNotifyExperimentObserver,
+        "NotifyExperimentObserver"
+      );
+    }
+    this.registeredCallbacks = {};
   },
 
   notifyBackground: function (data) {
-    if (ADDON_ID == "") {
+    if (this.addOnId == "") {
       throw new Error("notifyTools: ADDON_ID is empty!");
     }
     return new Promise((resolve) => {
       Services.obs.notifyObservers(
         { data, resolve },
         "NotifyBackgroundObserver",
-        ADDON_ID
+        this.addOnId
       );
     });
   },
-  
-  enable: function() {
-    Services.obs.addObserver(
-      this.onNotifyExperimentObserver,
-      "NotifyExperimentObserver",
-      false
-    );
+
+
+  // Deprecated.
+
+  enable: function () {
+    console.log("Manually calling notifyTools.enable() is no longer needed.");
   },
 
-  disable: function() {
-    Services.obs.removeObserver(
-      this.onNotifyExperimentObserver,
-      "NotifyExperimentObserver"
-    );
+  disable: function () {
+    console.log("notifyTools.disable() has been deprecated, use notifyTools.removeAllListeners() instead.");
+    this.removeAllListeners();
   },
+
+  registerListener: function (listener) {
+    console.log("notifyTools.registerListener() has been deprecated, use notifyTools.addListener() instead.");
+    this.addListener(listener);
+  },
+
 };
 
-
-if (window) {
+if (typeof window != "undefined" && window) {
   window.addEventListener(
-    "load",
+    "unload",
     function (event) {
-      notifyTools.enable();
-      window.addEventListener(
-        "unload",
-        function (event) {
-          notifyTools.disable();
-        },
-        false
-      );
+      notifyTools.removeAllListeners();
     },
     false
   );


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 .
Services global variable is available in WebExtensions experiments API global
from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 ,
and also available in all system globals from version 104
https://bugzilla.mozilla.org/show_bug.cgi?id=1667455 ,
and those code doesn't have to import Services.jsm for recent versions.